### PR TITLE
feat(equipment): implement missing audit APIs and integrate frontend …

### DIFF
--- a/src/main/java/com/fitlife/equipment/controller/EquipmentAreaController.java
+++ b/src/main/java/com/fitlife/equipment/controller/EquipmentAreaController.java
@@ -1,0 +1,52 @@
+package com.fitlife.equipment.controller;
+
+import com.fitlife.common.response.ApiResponse;
+import com.fitlife.equipment.dto.EquipmentAreaRequest;
+import com.fitlife.equipment.dto.EquipmentAreaResponse;
+import com.fitlife.equipment.service.EquipmentAreaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/equipment-areas")
+@RequiredArgsConstructor
+@Tag(name = "EquipmentArea", description = "APIs for managing gym equipment areas")
+@SecurityRequirement(name = "bearerAuth")
+@PreAuthorize("hasRole('ADMIN')")
+public class EquipmentAreaController {
+
+    private final EquipmentAreaService equipmentAreaService;
+
+    @PostMapping
+    @Operation(summary = "Create a new equipment area")
+    public ApiResponse<EquipmentAreaResponse> createArea(
+            @Valid @RequestBody EquipmentAreaRequest request
+    ) {
+        EquipmentAreaResponse response = equipmentAreaService.createArea(request);
+        return ApiResponse.success("Tạo khu vực thiết bị thành công", response);
+    }
+
+    @GetMapping
+    @Operation(summary = "Get list of all equipment areas")
+    public ApiResponse<List<EquipmentAreaResponse>> getAllAreas() {
+        List<EquipmentAreaResponse> response = equipmentAreaService.getAllAreas();
+        return ApiResponse.success("Lấy danh sách khu vực thiết bị thành công", response);
+    }
+
+    @PatchMapping("/{id}")
+    @Operation(summary = "Update an equipment area")
+    public ApiResponse<EquipmentAreaResponse> updateArea(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody EquipmentAreaRequest request
+    ) {
+        EquipmentAreaResponse response = equipmentAreaService.updateArea(id, request);
+        return ApiResponse.success("Cập nhật khu vực thiết bị thành công", response);
+    }
+}

--- a/src/main/java/com/fitlife/equipment/controller/EquipmentManagmentController.java
+++ b/src/main/java/com/fitlife/equipment/controller/EquipmentManagmentController.java
@@ -112,4 +112,46 @@ public class EquipmentManagmentController {
         MaintenanceScheduleResponse response = equipmentService.completeMaintenanceSchedule(id);
         return ApiResponse.success("Hoàn thành phiếu bảo trì thành công", response);
     }
+
+    @PostMapping("/staff/equipment/{id}/report-broken")
+    @Operation(summary = "Report equipment as broken and create a repair schedule")
+    @PreAuthorize("hasAnyRole('ADMIN', 'STAFF')")
+    public ApiResponse<MaintenanceScheduleResponse> reportBroken(
+            @PathVariable("id") String code,
+            @Valid @RequestBody EquipmentReportBrokenRequest request
+    ) {
+        MaintenanceScheduleResponse response = equipmentService.reportBroken(code, request);
+        return ApiResponse.success("Báo hỏng thiết bị thành công", response);
+    }
+
+    @PatchMapping("/admin/equipment/{id}/area")
+    @Operation(summary = "Update equipment area")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<EquipmentManagmentResponse> updateEquipmentArea(
+            @PathVariable("id") String code,
+            @Valid @RequestBody EquipmentAreaUpdateRequest request
+    ) {
+        EquipmentManagmentResponse response = equipmentService.updateEquipmentArea(code, request);
+        return ApiResponse.success("Cập nhật khu vực thiết bị thành công", response);
+    }
+
+    @PostMapping("/admin/equipment/{id}/retire")
+    @Operation(summary = "Retire equipment")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<EquipmentManagmentResponse> retireEquipment(
+            @PathVariable("id") String code
+    ) {
+        EquipmentManagmentResponse response = equipmentService.retireEquipment(code);
+        return ApiResponse.success("Ngừng hoạt động thiết bị thành công", response);
+    }
+
+    @GetMapping("/admin/equipment/{id}/history")
+    @Operation(summary = "Get equipment maintenance history")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<java.util.List<MaintenanceScheduleResponse>> getEquipmentHistory(
+            @PathVariable("id") String code
+    ) {
+        java.util.List<MaintenanceScheduleResponse> response = equipmentService.getEquipmentHistory(code);
+        return ApiResponse.success("Lấy lịch sử thiết bị thành công", response);
+    }
 }

--- a/src/main/java/com/fitlife/equipment/dto/EquipmentAreaRequest.java
+++ b/src/main/java/com/fitlife/equipment/dto/EquipmentAreaRequest.java
@@ -1,0 +1,22 @@
+package com.fitlife.equipment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EquipmentAreaRequest {
+
+    @NotBlank(message = "Tên khu vực không được để trống")
+    @Size(max = 150, message = "Tên khu vực không được quá 150 ký tự")
+    private String name;
+
+    @Size(max = 255, message = "Mô tả không được quá 255 ký tự")
+    private String description;
+}

--- a/src/main/java/com/fitlife/equipment/dto/EquipmentAreaResponse.java
+++ b/src/main/java/com/fitlife/equipment/dto/EquipmentAreaResponse.java
@@ -1,0 +1,20 @@
+package com.fitlife.equipment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EquipmentAreaResponse {
+    private Long id;
+    private String name;
+    private String description;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/fitlife/equipment/dto/EquipmentAreaUpdateRequest.java
+++ b/src/main/java/com/fitlife/equipment/dto/EquipmentAreaUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.fitlife.equipment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EquipmentAreaUpdateRequest {
+    @NotBlank(message = "Khu vực không được để trống")
+    private String area;
+}

--- a/src/main/java/com/fitlife/equipment/dto/EquipmentReportBrokenRequest.java
+++ b/src/main/java/com/fitlife/equipment/dto/EquipmentReportBrokenRequest.java
@@ -1,0 +1,16 @@
+package com.fitlife.equipment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EquipmentReportBrokenRequest {
+    @NotBlank(message = "Mô tả tình trạng hỏng không được để trống")
+    private String description;
+}

--- a/src/main/java/com/fitlife/equipment/entity/EquipmentArea.java
+++ b/src/main/java/com/fitlife/equipment/entity/EquipmentArea.java
@@ -1,0 +1,36 @@
+package com.fitlife.equipment.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "equipment_area")
+public class EquipmentArea {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, unique = true, length = 150)
+    private String name;
+
+    @Column(name = "description", length = 255)
+    private String description;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/fitlife/equipment/repository/EquipmentAreaRepository.java
+++ b/src/main/java/com/fitlife/equipment/repository/EquipmentAreaRepository.java
@@ -1,0 +1,14 @@
+package com.fitlife.equipment.repository;
+
+import com.fitlife.equipment.entity.EquipmentArea;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EquipmentAreaRepository extends JpaRepository<EquipmentArea, Long> {
+    Optional<EquipmentArea> findByName(String name);
+    boolean existsByName(String name);
+    boolean existsByNameAndIdNot(String name, Long id);
+}

--- a/src/main/java/com/fitlife/equipment/repository/EquipmentManagmentMaintenanceRepository.java
+++ b/src/main/java/com/fitlife/equipment/repository/EquipmentManagmentMaintenanceRepository.java
@@ -19,6 +19,8 @@ public interface EquipmentManagmentMaintenanceRepository extends JpaRepository<E
 
     List<EquipmentManagmentMaintenance> findByEquipmentIdAndStatusOrderByMaintenanceDateAsc(Long equipmentId, MaintenanceStatus status);
 
+    List<EquipmentManagmentMaintenance> findByEquipmentEquipmentCodeOrderByMaintenanceDateDesc(String equipmentCode);
+
     List<EquipmentManagmentMaintenance> findByStatusAndMaintenanceDateBetween(MaintenanceStatus status, LocalDate startDate, LocalDate endDate);
 
     Page<EquipmentManagmentMaintenance> findAllByOrderByMaintenanceDateDesc(Pageable pageable);

--- a/src/main/java/com/fitlife/equipment/service/EquipmentAreaService.java
+++ b/src/main/java/com/fitlife/equipment/service/EquipmentAreaService.java
@@ -1,0 +1,12 @@
+package com.fitlife.equipment.service;
+
+import com.fitlife.equipment.dto.EquipmentAreaRequest;
+import com.fitlife.equipment.dto.EquipmentAreaResponse;
+
+import java.util.List;
+
+public interface EquipmentAreaService {
+    EquipmentAreaResponse createArea(EquipmentAreaRequest request);
+    List<EquipmentAreaResponse> getAllAreas();
+    EquipmentAreaResponse updateArea(Long id, EquipmentAreaRequest request);
+}

--- a/src/main/java/com/fitlife/equipment/service/EquipmentManagmentService.java
+++ b/src/main/java/com/fitlife/equipment/service/EquipmentManagmentService.java
@@ -3,6 +3,7 @@ package com.fitlife.equipment.service;
 import com.fitlife.common.response.PageResponse;
 import com.fitlife.equipment.dto.*;
 import org.springframework.data.domain.Pageable;
+import java.util.List;
 
 public interface EquipmentManagmentService {
     PageResponse<EquipmentManagmentResponse> getEquipmentList(String keyword, String category, String status, String area, Pageable pageable);
@@ -22,4 +23,12 @@ public interface EquipmentManagmentService {
     PageResponse<MaintenanceScheduleResponse> getMaintenanceSchedules(Pageable pageable);
 
     MaintenanceScheduleResponse completeMaintenanceSchedule(Long id);
+
+    MaintenanceScheduleResponse reportBroken(String code, EquipmentReportBrokenRequest request);
+
+    EquipmentManagmentResponse updateEquipmentArea(String code, EquipmentAreaUpdateRequest request);
+
+    EquipmentManagmentResponse retireEquipment(String code);
+
+    List<MaintenanceScheduleResponse> getEquipmentHistory(String code);
 }

--- a/src/main/java/com/fitlife/equipment/service/impl/EquipmentAreaServiceImpl.java
+++ b/src/main/java/com/fitlife/equipment/service/impl/EquipmentAreaServiceImpl.java
@@ -1,0 +1,91 @@
+package com.fitlife.equipment.service.impl;
+
+import com.fitlife.common.exception.AppException;
+import com.fitlife.common.exception.ErrorCode;
+import com.fitlife.equipment.dto.EquipmentAreaRequest;
+import com.fitlife.equipment.dto.EquipmentAreaResponse;
+import com.fitlife.equipment.entity.EquipmentArea;
+import com.fitlife.equipment.entity.EquipmentManagment;
+import com.fitlife.equipment.repository.EquipmentAreaRepository;
+import com.fitlife.equipment.repository.EquipmentManagmentRepository;
+import com.fitlife.equipment.service.EquipmentAreaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class EquipmentAreaServiceImpl implements EquipmentAreaService {
+
+    private final EquipmentAreaRepository equipmentAreaRepository;
+    private final EquipmentManagmentRepository equipmentRepository;
+
+    @Override
+    @Transactional
+    public EquipmentAreaResponse createArea(EquipmentAreaRequest request) {
+        if (equipmentAreaRepository.existsByName(request.getName())) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "Tên khu vực đã tồn tại");
+        }
+
+        EquipmentArea area = EquipmentArea.builder()
+                .name(request.getName())
+                .description(request.getDescription())
+                .build();
+
+        EquipmentArea saved = equipmentAreaRepository.save(area);
+        return toResponse(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<EquipmentAreaResponse> getAllAreas() {
+        return equipmentAreaRepository.findAll().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public EquipmentAreaResponse updateArea(Long id, EquipmentAreaRequest request) {
+        EquipmentArea area = equipmentAreaRepository.findById(id)
+                .orElseThrow(() -> new AppException(ErrorCode.INVALID_REQUEST, "Không tìm thấy khu vực"));
+
+        if (equipmentAreaRepository.existsByNameAndIdNot(request.getName(), id)) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "Tên khu vực đã tồn tại");
+        }
+
+        String oldName = area.getName();
+        String newName = request.getName();
+
+        area.setName(newName);
+        area.setDescription(request.getDescription());
+
+        EquipmentArea saved = equipmentAreaRepository.save(area);
+
+        // Cascade name change to existing equipment string field
+        if (!oldName.equals(newName)) {
+            List<EquipmentManagment> equipments = equipmentRepository.findAll();
+            for (EquipmentManagment eq : equipments) {
+                if (oldName.equals(eq.getArea())) {
+                    eq.setArea(newName);
+                    equipmentRepository.save(eq);
+                }
+            }
+        }
+
+        return toResponse(saved);
+    }
+
+    private EquipmentAreaResponse toResponse(EquipmentArea area) {
+        return EquipmentAreaResponse.builder()
+                .id(area.getId())
+                .name(area.getName())
+                .description(area.getDescription())
+                .createdAt(area.getCreatedAt())
+                .updatedAt(area.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/fitlife/equipment/service/impl/EquipmentManagmentServiceImpl.java
+++ b/src/main/java/com/fitlife/equipment/service/impl/EquipmentManagmentServiceImpl.java
@@ -242,4 +242,69 @@ public class EquipmentManagmentServiceImpl implements EquipmentManagmentService 
                     dto.setDaysToNextMaintenance((int) ChronoUnit.DAYS.between(today, m.getMaintenanceDate()));
                 });
     }
+
+    @Override
+    @Transactional
+    public MaintenanceScheduleResponse reportBroken(String code, EquipmentReportBrokenRequest request) {
+        EquipmentManagment eq = equipmentRepository.findByEquipmentCodeAndIsDeletedFalse(code)
+                .orElseThrow(() -> new AppException(ErrorCode.EQUIPMENT_NOT_FOUND));
+
+        eq.setStatus(EquipmentManagmentStatus.MAINTENANCE);
+        equipmentRepository.save(eq);
+
+        EquipmentManagmentMaintenance maintenance = EquipmentManagmentMaintenance.builder()
+                .equipment(eq)
+                .maintenanceDate(LocalDate.now())
+                .maintenanceType("REPAIR")
+                .description(request.getDescription())
+                .cost(BigDecimal.ZERO)
+                .status(MaintenanceStatus.SCHEDULED)
+                .build();
+
+        EquipmentManagmentMaintenance saved = maintenanceRepository.save(maintenance);
+        return equipmentMapper.toMaintenanceResponse(saved);
+    }
+
+    @Override
+    @Transactional
+    public EquipmentManagmentResponse updateEquipmentArea(String code, EquipmentAreaUpdateRequest request) {
+        EquipmentManagment eq = equipmentRepository.findByEquipmentCodeAndIsDeletedFalse(code)
+                .orElseThrow(() -> new AppException(ErrorCode.EQUIPMENT_NOT_FOUND));
+
+        eq.setArea(request.getArea());
+        EquipmentManagment saved = equipmentRepository.save(eq);
+
+        EquipmentManagmentResponse response = equipmentMapper.toResponse(saved);
+        enrichMaintenanceDates(response, saved);
+        return response;
+    }
+
+    @Override
+    @Transactional
+    public EquipmentManagmentResponse retireEquipment(String code) {
+        EquipmentManagment eq = equipmentRepository.findByEquipmentCodeAndIsDeletedFalse(code)
+                .orElseThrow(() -> new AppException(ErrorCode.EQUIPMENT_NOT_FOUND));
+
+        eq.setStatus(EquipmentManagmentStatus.INACTIVE);
+        EquipmentManagment saved = equipmentRepository.save(eq);
+
+        EquipmentManagmentResponse response = equipmentMapper.toResponse(saved);
+        enrichMaintenanceDates(response, saved);
+        return response;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MaintenanceScheduleResponse> getEquipmentHistory(String code) {
+        if (!equipmentRepository.existsByEquipmentCodeAndIsDeletedFalse(code)) {
+            throw new AppException(ErrorCode.EQUIPMENT_NOT_FOUND);
+        }
+
+        List<EquipmentManagmentMaintenance> history = maintenanceRepository
+                .findByEquipmentEquipmentCodeOrderByMaintenanceDateDesc(code);
+
+        return history.stream()
+                .map(equipmentMapper::toMaintenanceResponse)
+                .collect(java.util.stream.Collectors.toList());
+    }
 }

--- a/src/main/resources/db/migration/V23__create_equipment_areas_table.sql
+++ b/src/main/resources/db/migration/V23__create_equipment_areas_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE equipment_area (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(150) NOT NULL UNIQUE,
+    description VARCHAR(255) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+INSERT INTO equipment_area (name) VALUES ('Khu Cardio – Tầng 1');
+INSERT INTO equipment_area (name) VALUES ('Khu Sức mạnh – Tầng 2');


### PR DESCRIPTION
  - Implement EQUIP-03, EQUIP-04, EQUIP-05, EQUIP-06, EQUIP-12, EQUIP-13, EQUIP-14.
  - Create V23 schema migration for equipment areas table and seed data.
  - Add report-broken, retire, quick-area update, and maintenance history endpoints.
  - Adjust Spring Security for public uploads folder access and Staff roles.
  - Fix pagination index offset bugs in Equipment and Member controllers.