### PR TITLE
fix(Package & Subscription):align gym package, package duration, and subscription

### DIFF
--- a/src/main/java/com/fitlife/gympackage/controller/PackageDurationController.java
+++ b/src/main/java/com/fitlife/gympackage/controller/PackageDurationController.java
@@ -25,7 +25,7 @@ public class PackageDurationController {
 
     private final PackageDurationService packageDurationService;
 
-    @GetMapping("/package-durations")
+    @GetMapping({"/package-durations", "/package-durations/active"})
     @Operation(summary = "Get list of active package durations")
     public ApiResponse<List<PackageDurationResponse>> getActiveDurationsList() {
         List<PackageDurationResponse> response = packageDurationService.getActiveDurationsList();
@@ -59,7 +59,7 @@ public class PackageDurationController {
         return ApiResponse.created("Tạo thời hạn thành công", response);
     }
 
-    @PutMapping("/admin/package-durations/{id}")
+    @RequestMapping(value = "/admin/package-durations/{id}", method = {RequestMethod.PUT, RequestMethod.PATCH})
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update a package duration")
     public ApiResponse<PackageDurationResponse> updateDuration(

--- a/src/main/java/com/fitlife/gympackage/dto/PackageDurationCreateRequest.java
+++ b/src/main/java/com/fitlife/gympackage/dto/PackageDurationCreateRequest.java
@@ -32,5 +32,7 @@ public class PackageDurationCreateRequest {
     private BigDecimal price;
     private BigDecimal discountPrice;
 
+    private Long gymPackageId;
+
     private String status;
 }

--- a/src/main/java/com/fitlife/gympackage/dto/PackageDurationResponse.java
+++ b/src/main/java/com/fitlife/gympackage/dto/PackageDurationResponse.java
@@ -21,6 +21,8 @@ public class PackageDurationResponse {
     private BigDecimal price;
     private BigDecimal discountPrice;
     private BigDecimal discountPercent;
+    private Long gymPackageId;
+    private String gymPackageName;
     private String status;
 
     @JsonFormat(pattern = "dd/MM/yyyy HH:mm:ss")

--- a/src/main/java/com/fitlife/gympackage/mapper/PackageDurationMapper.java
+++ b/src/main/java/com/fitlife/gympackage/mapper/PackageDurationMapper.java
@@ -11,6 +11,8 @@ import org.mapstruct.MappingTarget;
 @Mapper(componentModel = "spring")
 public interface PackageDurationMapper {
 
+    @Mapping(target = "gymPackageId", source = "gymPackage.id")
+    @Mapping(target = "gymPackageName", source = "gymPackage.name")
     PackageDurationResponse toResponse(PackageDuration entity);
 
     @Mapping(target = "id", ignore = true)

--- a/src/main/java/com/fitlife/gympackage/service/impl/GymPackageServiceImpl.java
+++ b/src/main/java/com/fitlife/gympackage/service/impl/GymPackageServiceImpl.java
@@ -188,7 +188,12 @@ public class GymPackageServiceImpl implements GymPackageService {
         GymPackage pkg = gymPackageRepository.findByIdAndIsDeletedFalse(id)
                 .orElseThrow(() -> new AppException(ErrorCode.PACKAGE_NOT_FOUND, "Package not found"));
 
-        pkg.setStatus(request.getStatus().toUpperCase());
+        String status = request.getStatus();
+        if (status == null || status.isBlank()) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "Trạng thái không được để trống");
+        }
+
+        pkg.setStatus(status.toUpperCase());
         GymPackage saved = gymPackageRepository.save(pkg);
         return gymPackageMapper.toResponse(saved);
     }
@@ -199,9 +204,12 @@ public class GymPackageServiceImpl implements GymPackageService {
         GymPackage pkg = gymPackageRepository.findByIdAndIsDeletedFalse(id)
                 .orElseThrow(() -> new AppException(ErrorCode.PACKAGE_NOT_FOUND, "Package not found"));
 
-        boolean hasActive = subscriptionRepository.existsByGymPackageIdAndStatus(id, SubscriptionStatus.ACTIVE);
-        if (hasActive) {
-            throw new AppException(ErrorCode.INVALID_REQUEST, "Cannot delete package with active subscriptions");
+        boolean hasActiveOrPending = subscriptionRepository.existsByGymPackageIdAndStatus(id, SubscriptionStatus.ACTIVE)
+                || subscriptionRepository.existsByGymPackageIdAndStatus(id, SubscriptionStatus.PENDING_PAYMENT)
+                || subscriptionRepository.existsByGymPackageIdAndStatus(id, SubscriptionStatus.PAUSED)
+                || subscriptionRepository.existsByGymPackageIdAndStatus(id, SubscriptionStatus.SUSPENDED);
+        if (hasActiveOrPending) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "Không thể xóa gói tập đang có người đăng ký hoạt động hoặc chờ thanh toán");
         }
 
         pkg.setIsDeleted(true);

--- a/src/main/java/com/fitlife/gympackage/service/impl/PackageDurationServiceImpl.java
+++ b/src/main/java/com/fitlife/gympackage/service/impl/PackageDurationServiceImpl.java
@@ -65,6 +65,54 @@ public class PackageDurationServiceImpl implements PackageDurationService {
             duration.setStatus("ACTIVE");
         }
 
+        Long packageId = request.getGymPackageId();
+        if (packageId != null) {
+            GymPackage gymPackage = gymPackageRepository.findByIdAndIsDeletedFalse(packageId)
+                    .orElseThrow(() -> new AppException(ErrorCode.PACKAGE_NOT_FOUND, "Package not found"));
+            duration.setGymPackage(gymPackage);
+        } else {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "gymPackageId is required");
+        }
+
+        Integer months = request.getMonths() != null ? request.getMonths() : request.getDurationMonths();
+        if (months == null || months <= 0) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "durationMonths must be >= 1");
+        }
+        duration.setMonths(months);
+
+        BigDecimal price = request.getPrice();
+        if (price == null || price.compareTo(BigDecimal.ZERO) < 0) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "price must be > 0");
+        }
+        duration.setPrice(price);
+
+        BigDecimal discountPrice = request.getDiscountPrice();
+        if (discountPrice != null) {
+            if (discountPrice.compareTo(BigDecimal.ZERO) < 0) {
+                throw new AppException(ErrorCode.INVALID_REQUEST, "Discount price must be >= 0");
+            }
+            if (discountPrice.compareTo(price) > 0) {
+                throw new AppException(ErrorCode.INVALID_REQUEST, "Discount price cannot be greater than original price");
+            }
+            duration.setDiscountPrice(discountPrice);
+        } else {
+            duration.setDiscountPrice(price);
+            discountPrice = price;
+        }
+
+        boolean existsMonths = packageDurationRepository.findByGymPackageIdAndMonthsAndStatus(packageId, months, "ACTIVE").isPresent();
+        if (existsMonths) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "Duration for this month count already exists in package");
+        }
+
+        BigDecimal discountPercent = BigDecimal.ZERO;
+        if (price.compareTo(BigDecimal.ZERO) > 0) {
+            discountPercent = price.subtract(discountPrice)
+                    .multiply(BigDecimal.valueOf(100))
+                    .divide(price, 2, java.math.RoundingMode.HALF_UP);
+        }
+        duration.setDiscountPercent(discountPercent);
+
         PackageDuration saved = packageDurationRepository.save(duration);
         return packageDurationMapper.toResponse(saved);
     }
@@ -139,6 +187,10 @@ public class PackageDurationServiceImpl implements PackageDurationService {
         PackageDuration duration = packageDurationRepository.findById(id)
                 .orElseThrow(() -> new AppException(ErrorCode.DURATION_NOT_FOUND, "Package duration not found"));
 
+        if (status == null || status.isBlank()) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "Trạng thái không được để trống");
+        }
+
         duration.setStatus(status.toUpperCase());
         PackageDuration saved = packageDurationRepository.save(duration);
         return packageDurationMapper.toResponse(saved);
@@ -150,9 +202,12 @@ public class PackageDurationServiceImpl implements PackageDurationService {
         PackageDuration duration = packageDurationRepository.findById(id)
                 .orElseThrow(() -> new AppException(ErrorCode.DURATION_NOT_FOUND, "Package duration not found"));
 
-        boolean hasActive = subscriptionRepository.existsByPackageDurationIdAndStatus(id, SubscriptionStatus.ACTIVE);
-        if (hasActive) {
-            throw new AppException(ErrorCode.INVALID_REQUEST, "Cannot delete duration referenced in active subscriptions");
+        boolean hasActiveOrPending = subscriptionRepository.existsByPackageDurationIdAndStatus(id, SubscriptionStatus.ACTIVE)
+                || subscriptionRepository.existsByPackageDurationIdAndStatus(id, SubscriptionStatus.PENDING_PAYMENT)
+                || subscriptionRepository.existsByPackageDurationIdAndStatus(id, SubscriptionStatus.PAUSED)
+                || subscriptionRepository.existsByPackageDurationIdAndStatus(id, SubscriptionStatus.SUSPENDED);
+        if (hasActiveOrPending) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "Không thể xóa thời hạn đang có người đăng ký hoạt động hoặc chờ thanh toán");
         }
 
         packageDurationRepository.delete(duration);

--- a/src/main/java/com/fitlife/payment/service/impl/VnpayServiceImpl.java
+++ b/src/main/java/com/fitlife/payment/service/impl/VnpayServiceImpl.java
@@ -5,6 +5,7 @@ import com.fitlife.common.exception.ErrorCode;
 import com.fitlife.subscription.entity.Subscription;
 import com.fitlife.subscription.enums.SubscriptionStatus;
 import com.fitlife.subscription.repository.SubscriptionRepository;
+import com.fitlife.subscription.service.SubscriptionService;
 import com.fitlife.invoice.entity.Invoice;
 import com.fitlife.invoice.enums.InvoiceStatus;
 import com.fitlife.invoice.repository.InvoiceRepository;
@@ -39,6 +40,7 @@ public class VnpayServiceImpl implements VnpayService {
     private final InvoiceRepository invoiceRepository;
     private final PaymentRepository paymentRepository;
     private final SubscriptionRepository subscriptionRepository;
+    private final SubscriptionService subscriptionService;
 
     private static final DateTimeFormatter VNP_DATE_FORMAT =
             DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
@@ -258,8 +260,7 @@ public class VnpayServiceImpl implements VnpayService {
         Subscription subscription = invoice.getSubscription();
 
         if (subscription != null) {
-            activateSubscription(subscription);
-            subscriptionRepository.save(subscription);
+            subscriptionService.activateSubscriptionAfterPayment(subscription.getId());
         }
 
         paymentRepository.save(payment);
@@ -278,23 +279,6 @@ public class VnpayServiceImpl implements VnpayService {
         payment.setGatewayMessage("VNPay payment failed");
 
         paymentRepository.save(payment);
-    }
-
-    private void activateSubscription(Subscription subscription) {
-        if (subscription.getStatus() == SubscriptionStatus.ACTIVE) {
-            return;
-        }
-
-        LocalDate startDate = LocalDate.now();
-
-        subscription.setStatus(SubscriptionStatus.ACTIVE);
-        subscription.setStartDate(startDate);
-
-        if (subscription.getPackageDuration() != null) {
-            subscription.setEndDate(
-                    startDate.plusMonths(subscription.getPackageDuration().getMonths())
-            );
-        }
     }
 
     private String buildFrontendRedirect(String status, String code, Long paymentId) {

--- a/src/main/java/com/fitlife/security/SecurityConfiguration.java
+++ b/src/main/java/com/fitlife/security/SecurityConfiguration.java
@@ -167,6 +167,12 @@ public class SecurityConfiguration {
                         ).hasAnyRole("ADMIN", "STAFF")
 
                         .requestMatchers(
+                                HttpMethod.GET,
+                                "/admin/subscriptions",
+                                "/admin/subscriptions/**"
+                        ).hasAnyRole("ADMIN", "STAFF")
+
+                        .requestMatchers(
                                 "/admin/**"
                         ).hasRole("ADMIN")
 

--- a/src/main/java/com/fitlife/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/fitlife/subscription/controller/SubscriptionController.java
@@ -35,14 +35,14 @@ public class SubscriptionController {
                 .build();
     }
 
-    @GetMapping("/my")
+    @GetMapping({"/my", "/me"})
     public ApiResponse<?> getMySubscriptions(Pageable pageable) {
         return ApiResponse.builder()
                 .data(subscriptionService.getMySubscriptions(pageable))
                 .build();
     }
 
-    @GetMapping("/my/active")
+    @GetMapping({"/my/active", "/me/active"})
     public ApiResponse<SubscriptionResponse> getMyActiveSubscription() {
         return ApiResponse.<SubscriptionResponse>builder()
                 .data(subscriptionService.getMyActiveSubscription())

--- a/src/main/java/com/fitlife/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/fitlife/subscription/service/SubscriptionService.java
@@ -36,4 +36,6 @@ public interface SubscriptionService {
     SubscriptionResponse createSubscriptionForMemberByStaff(Long memberId, SubscriptionCreateRequest request);
 
     SubscriptionResponse updateSubscriptionStatusByAdmin(Long subscriptionId, com.fitlife.subscription.dto.request.SubscriptionStatusUpdateRequest request);
+
+    void activateSubscriptionAfterPayment(Long subscriptionId);
 }

--- a/src/main/java/com/fitlife/subscription/service/impl/SubscriptionServiceImpl.java
+++ b/src/main/java/com/fitlife/subscription/service/impl/SubscriptionServiceImpl.java
@@ -652,4 +652,51 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         return memberRepository.findByUserId(user.getId())
                 .orElseThrow(() -> new AppException(ErrorCode.MEMBER_NOT_FOUND));
     }
+
+    @Override
+    @Transactional
+    public void activateSubscriptionAfterPayment(Long subscriptionId) {
+        Subscription subscription = subscriptionRepository.findById(subscriptionId)
+                .orElseThrow(() -> new AppException(ErrorCode.SUBSCRIPTION_NOT_FOUND, "Subscription not found"));
+
+        if (subscription.getStatus() == SubscriptionStatus.ACTIVE) {
+            return;
+        }
+
+        SubscriptionStatus oldStatus = subscription.getStatus();
+        LocalDate startDate = LocalDate.now();
+
+        subscription.setStatus(SubscriptionStatus.ACTIVE);
+        if (subscription.getStartDate() == null) {
+            subscription.setStartDate(startDate);
+            if (subscription.getPackageDuration() != null) {
+                subscription.setEndDate(
+                        startDate.plusMonths(subscription.getPackageDuration().getMonths())
+                );
+            }
+        }
+
+        subscriptionRepository.save(subscription);
+        logHistory(subscription, oldStatus, SubscriptionStatus.ACTIVE, "PAYMENT_ACTIVATED", "Subscription activated via payment success");
+
+        // Handle replacement for UPGRADE
+        String note = subscription.getNote();
+        if (note != null && note.startsWith("UPGRADE_FROM_")) {
+            try {
+                String oldSubIdStr = note.substring("UPGRADE_FROM_".length()).trim();
+                Long oldSubId = Long.parseLong(oldSubIdStr);
+                subscriptionRepository.findById(oldSubId).ifPresent(oldSub -> {
+                    if (oldSub.getStatus() == SubscriptionStatus.ACTIVE) {
+                        SubscriptionStatus oldSubPrevStatus = oldSub.getStatus();
+                        oldSub.setStatus(SubscriptionStatus.CANCELLED);
+                        oldSub.setNote("Upgraded to subscription " + subscription.getId());
+                        subscriptionRepository.save(oldSub);
+                        logHistory(oldSub, oldSubPrevStatus, SubscriptionStatus.CANCELLED, "UPGRADE_REPLACE", "Cancelled due to upgrade to " + subscription.getId());
+                    }
+                });
+            } catch (Exception e) {
+                // Ignore parsing errors
+            }
+        }
+    }
 }

--- a/src/test/java/com/fitlife/gympackage/service/impl/GymPackageServiceImplTest.java
+++ b/src/test/java/com/fitlife/gympackage/service/impl/GymPackageServiceImplTest.java
@@ -1,0 +1,202 @@
+package com.fitlife.gympackage.service.impl;
+
+import com.fitlife.common.exception.AppException;
+import com.fitlife.common.response.PageResponse;
+import com.fitlife.gympackage.dto.GymPackageCreateRequest;
+import com.fitlife.gympackage.dto.GymPackageResponse;
+import com.fitlife.gympackage.dto.GymPackageUpdateRequest;
+import com.fitlife.gympackage.dto.GymPackageVisibilityRequest;
+import com.fitlife.gympackage.entity.GymPackage;
+import com.fitlife.gympackage.mapper.GymPackageMapper;
+import com.fitlife.gympackage.repository.GymPackageRepository;
+import com.fitlife.subscription.enums.SubscriptionStatus;
+import com.fitlife.subscription.repository.SubscriptionRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GymPackageServiceImplTest {
+
+    @Mock
+    private GymPackageRepository gymPackageRepository;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private GymPackageMapper gymPackageMapper;
+
+    @InjectMocks
+    private GymPackageServiceImpl gymPackageService;
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getPackagesList_shouldFilterActiveOnly_forGuestOrMember() {
+        SecurityContextHolder.clearContext(); // Guest
+
+        Pageable pageable = PageRequest.of(0, 10);
+        GymPackage pkg = GymPackage.builder().id(1L).name("Basic").status("ACTIVE").isDeleted(false).build();
+        Page<GymPackage> page = new PageImpl<>(List.of(pkg));
+
+        when(gymPackageRepository.searchPackages(null, null, "ACTIVE", pageable))
+                .thenReturn(page);
+        when(gymPackageMapper.toResponse(any(GymPackage.class)))
+                .thenReturn(GymPackageResponse.builder().id(1L).name("Basic").status("ACTIVE").build());
+
+        PageResponse<GymPackageResponse> response = gymPackageService.getPackagesList(null, null, null, pageable);
+
+        assertNotNull(response);
+        assertEquals(1, response.getContent().size());
+        assertEquals("Basic", response.getContent().get(0).getName());
+        verify(gymPackageRepository).searchPackages(null, null, "ACTIVE", pageable);
+    }
+
+    @Test
+    void getPackagesList_shouldAllowAllStatus_forAdminOrStaff() {
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                "admin", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        Pageable pageable = PageRequest.of(0, 10);
+        GymPackage pkg = GymPackage.builder().id(1L).name("Basic").status("INACTIVE").isDeleted(false).build();
+        Page<GymPackage> page = new PageImpl<>(List.of(pkg));
+
+        when(gymPackageRepository.searchPackages(null, null, "INACTIVE", pageable))
+                .thenReturn(page);
+        when(gymPackageMapper.toResponse(any(GymPackage.class)))
+                .thenReturn(GymPackageResponse.builder().id(1L).name("Basic").status("INACTIVE").build());
+
+        PageResponse<GymPackageResponse> response = gymPackageService.getPackagesList(null, null, "INACTIVE", pageable);
+
+        assertNotNull(response);
+        assertEquals("INACTIVE", response.getContent().get(0).getStatus());
+        verify(gymPackageRepository).searchPackages(null, null, "INACTIVE", pageable);
+    }
+
+    @Test
+    void getPackageById_shouldThrowException_whenPackageIsInactiveAndUserIsGuest() {
+        SecurityContextHolder.clearContext();
+
+        GymPackage pkg = GymPackage.builder().id(1L).name("Premium").status("INACTIVE").isDeleted(false).build();
+        when(gymPackageRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(pkg));
+
+        assertThrows(AppException.class, () -> gymPackageService.getPackageById(1L));
+    }
+
+    @Test
+    void getPackageById_shouldReturnPackage_whenPackageIsInactiveAndUserIsAdmin() {
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                "admin", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        GymPackage pkg = GymPackage.builder().id(1L).name("Premium").status("INACTIVE").isDeleted(false).build();
+        when(gymPackageRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(pkg));
+        when(gymPackageMapper.toResponse(pkg))
+                .thenReturn(GymPackageResponse.builder().id(1L).name("Premium").status("INACTIVE").build());
+
+        GymPackageResponse response = gymPackageService.getPackageById(1L);
+
+        assertNotNull(response);
+        assertEquals("Premium", response.getName());
+    }
+
+    @Test
+    void createPackage_shouldThrowException_whenNameExists() {
+        GymPackageCreateRequest request = GymPackageCreateRequest.builder().name("Exist").code("EXIST-01").build();
+        when(gymPackageRepository.existsByNameAndIsDeletedFalse("Exist")).thenReturn(true);
+
+        assertThrows(AppException.class, () -> gymPackageService.createPackage(request));
+    }
+
+    @Test
+    void createPackage_shouldSave_whenDataIsValid() {
+        GymPackageCreateRequest request = GymPackageCreateRequest.builder()
+                .name("New Pkg")
+                .code("NEW-01")
+                .basePrice(BigDecimal.TEN)
+                .packageType("VIP")
+                .hasAiWorkoutPlan(true)
+                .hasNutritionPlan(true)
+                .ptSessionsPerMonth(4)
+                .status("ACTIVE")
+                .build();
+
+        when(gymPackageRepository.existsByNameAndIsDeletedFalse("New Pkg")).thenReturn(false);
+        when(gymPackageRepository.existsByCodeAndIsDeletedFalse("NEW-01")).thenReturn(false);
+        when(gymPackageRepository.save(any(GymPackage.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(gymPackageMapper.toResponse(any(GymPackage.class))).thenAnswer(invocation -> {
+            GymPackage pkg = invocation.getArgument(0);
+            return GymPackageResponse.builder()
+                    .id(1L)
+                    .name(pkg.getName())
+                    .code(pkg.getCode())
+                    .status(pkg.getStatus())
+                    .build();
+        });
+
+        GymPackageResponse response = gymPackageService.createPackage(request);
+
+        assertNotNull(response);
+        assertEquals("New Pkg", response.getName());
+        assertEquals("NEW-01", response.getCode());
+    }
+
+    @Test
+    void updateVisibility_shouldThrowException_whenStatusIsBlank() {
+        GymPackage pkg = GymPackage.builder().id(1L).name("Pkg").status("ACTIVE").build();
+        when(gymPackageRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(pkg));
+
+        GymPackageVisibilityRequest request = GymPackageVisibilityRequest.builder().status("").build();
+
+        assertThrows(AppException.class, () -> gymPackageService.updateVisibility(1L, request));
+    }
+
+    @Test
+    void deletePackage_shouldThrowException_whenHasActiveSubscriptions() {
+        GymPackage pkg = GymPackage.builder().id(1L).name("Pkg").status("ACTIVE").build();
+        when(gymPackageRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(pkg));
+        when(subscriptionRepository.existsByGymPackageIdAndStatus(1L, SubscriptionStatus.ACTIVE)).thenReturn(true);
+
+        assertThrows(AppException.class, () -> gymPackageService.deletePackage(1L));
+    }
+
+    @Test
+    void deletePackage_shouldSoftDelete_whenNoActiveSubscriptions() {
+        GymPackage pkg = GymPackage.builder().id(1L).name("Pkg").status("ACTIVE").isDeleted(false).build();
+        when(gymPackageRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(pkg));
+        when(subscriptionRepository.existsByGymPackageIdAndStatus(1L, SubscriptionStatus.ACTIVE)).thenReturn(false);
+        when(subscriptionRepository.existsByGymPackageIdAndStatus(1L, SubscriptionStatus.PENDING_PAYMENT)).thenReturn(false);
+        when(subscriptionRepository.existsByGymPackageIdAndStatus(1L, SubscriptionStatus.PAUSED)).thenReturn(false);
+        when(subscriptionRepository.existsByGymPackageIdAndStatus(1L, SubscriptionStatus.SUSPENDED)).thenReturn(false);
+
+        gymPackageService.deletePackage(1L);
+
+        assertTrue(pkg.getIsDeleted());
+        verify(gymPackageRepository).save(pkg);
+    }
+}

--- a/src/test/java/com/fitlife/gympackage/service/impl/PackageDurationServiceImplTest.java
+++ b/src/test/java/com/fitlife/gympackage/service/impl/PackageDurationServiceImplTest.java
@@ -1,0 +1,135 @@
+package com.fitlife.gympackage.service.impl;
+
+import com.fitlife.common.exception.AppException;
+import com.fitlife.gympackage.dto.PackageDurationCreateRequest;
+import com.fitlife.gympackage.dto.PackageDurationResponse;
+import com.fitlife.gympackage.dto.PackageDurationUpdateRequest;
+import com.fitlife.gympackage.entity.GymPackage;
+import com.fitlife.gympackage.entity.PackageDuration;
+import com.fitlife.gympackage.mapper.PackageDurationMapper;
+import com.fitlife.gympackage.repository.GymPackageRepository;
+import com.fitlife.gympackage.repository.PackageDurationRepository;
+import com.fitlife.subscription.enums.SubscriptionStatus;
+import com.fitlife.subscription.repository.SubscriptionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PackageDurationServiceImplTest {
+
+    @Mock
+    private PackageDurationRepository packageDurationRepository;
+
+    @Mock
+    private GymPackageRepository gymPackageRepository;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private PackageDurationMapper packageDurationMapper;
+
+    @InjectMocks
+    private PackageDurationServiceImpl packageDurationService;
+
+    @Test
+    void getActiveDurationsList_shouldReturnActiveDurations() {
+        PackageDuration duration = PackageDuration.builder().id(1L).code("DUR_1M").status("ACTIVE").build();
+        when(packageDurationRepository.findByStatus("ACTIVE")).thenReturn(List.of(duration));
+        when(packageDurationMapper.toResponse(any(PackageDuration.class)))
+                .thenReturn(PackageDurationResponse.builder().id(1L).code("DUR_1M").status("ACTIVE").build());
+
+        List<PackageDurationResponse> result = packageDurationService.getActiveDurationsList();
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("DUR_1M", result.get(0).getCode());
+    }
+
+    @Test
+    void createDuration_shouldThrowException_whenCodeExists() {
+        PackageDurationCreateRequest request = PackageDurationCreateRequest.builder().code("DUR_1M").build();
+        when(packageDurationRepository.existsByCode("DUR_1M")).thenReturn(true);
+
+        assertThrows(AppException.class, () -> packageDurationService.createDuration(request));
+    }
+
+    @Test
+    void createDuration_shouldThrowException_whenPackageNotFound() {
+        PackageDurationCreateRequest request = PackageDurationCreateRequest.builder().code("DUR_1M").gymPackageId(999L).build();
+        when(packageDurationRepository.existsByCode("DUR_1M")).thenReturn(false);
+        when(packageDurationMapper.toEntity(request)).thenReturn(new PackageDuration());
+        when(gymPackageRepository.findByIdAndIsDeletedFalse(999L)).thenReturn(Optional.empty());
+
+        assertThrows(AppException.class, () -> packageDurationService.createDuration(request));
+    }
+
+    @Test
+    void createDuration_shouldSave_whenValid() {
+        PackageDurationCreateRequest request = PackageDurationCreateRequest.builder()
+                .code("DUR_1M")
+                .name("1 Month")
+                .months(1)
+                .price(BigDecimal.valueOf(100))
+                .discountPrice(BigDecimal.valueOf(80))
+                .gymPackageId(1L)
+                .status("ACTIVE")
+                .build();
+
+        GymPackage gymPackage = GymPackage.builder().id(1L).name("VIP").build();
+        PackageDuration duration = new PackageDuration();
+
+        when(packageDurationRepository.existsByCode("DUR_1M")).thenReturn(false);
+        when(packageDurationMapper.toEntity(request)).thenReturn(duration);
+        when(gymPackageRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(gymPackage));
+        when(packageDurationRepository.findByGymPackageIdAndMonthsAndStatus(1L, 1, "ACTIVE")).thenReturn(Optional.empty());
+        when(packageDurationRepository.save(any(PackageDuration.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(packageDurationMapper.toResponse(any(PackageDuration.class)))
+                .thenReturn(PackageDurationResponse.builder().id(10L).code("DUR_1M").status("ACTIVE").build());
+
+        PackageDurationResponse response = packageDurationService.createDuration(request);
+
+        assertNotNull(response);
+        assertEquals(10L, response.getId());
+    }
+
+    @Test
+    void updateDuration_shouldThrowException_whenNotFound() {
+        when(packageDurationRepository.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(AppException.class, () -> packageDurationService.updateDuration(1L, new PackageDurationUpdateRequest()));
+    }
+
+    @Test
+    void deleteDuration_shouldThrowException_whenHasActiveSubscriptions() {
+        PackageDuration duration = PackageDuration.builder().id(1L).build();
+        when(packageDurationRepository.findById(1L)).thenReturn(Optional.of(duration));
+        when(subscriptionRepository.existsByPackageDurationIdAndStatus(1L, SubscriptionStatus.ACTIVE)).thenReturn(true);
+
+        assertThrows(AppException.class, () -> packageDurationService.deleteDuration(1L));
+    }
+
+    @Test
+    void deleteDuration_shouldDelete_whenNoActiveSubscriptions() {
+        PackageDuration duration = PackageDuration.builder().id(1L).build();
+        when(packageDurationRepository.findById(1L)).thenReturn(Optional.of(duration));
+        when(subscriptionRepository.existsByPackageDurationIdAndStatus(1L, SubscriptionStatus.ACTIVE)).thenReturn(false);
+        when(subscriptionRepository.existsByPackageDurationIdAndStatus(1L, SubscriptionStatus.PENDING_PAYMENT)).thenReturn(false);
+        when(subscriptionRepository.existsByPackageDurationIdAndStatus(1L, SubscriptionStatus.PAUSED)).thenReturn(false);
+        when(subscriptionRepository.existsByPackageDurationIdAndStatus(1L, SubscriptionStatus.SUSPENDED)).thenReturn(false);
+
+        packageDurationService.deleteDuration(1L);
+
+        verify(packageDurationRepository).delete(duration);
+    }
+}

--- a/src/test/java/com/fitlife/subscription/service/impl/SubscriptionServiceImplTest.java
+++ b/src/test/java/com/fitlife/subscription/service/impl/SubscriptionServiceImplTest.java
@@ -1,0 +1,165 @@
+package com.fitlife.subscription.service.impl;
+
+import com.fitlife.common.exception.AppException;
+import com.fitlife.gympackage.entity.GymPackage;
+import com.fitlife.gympackage.entity.PackageDuration;
+import com.fitlife.gympackage.repository.GymPackageRepository;
+import com.fitlife.gympackage.repository.PackageDurationRepository;
+import com.fitlife.invoice.service.InvoiceService;
+import com.fitlife.member.entity.Member;
+import com.fitlife.member.repository.MemberRepository;
+import com.fitlife.subscription.dto.request.SubscriptionCreateRequest;
+import com.fitlife.subscription.entity.Subscription;
+import com.fitlife.subscription.entity.SubscriptionHistory;
+import com.fitlife.subscription.enums.SubscriptionStatus;
+import com.fitlife.subscription.mapper.SubscriptionMapper;
+import com.fitlife.subscription.repository.SubscriptionHistoryRepository;
+import com.fitlife.subscription.repository.SubscriptionRepository;
+import com.fitlife.user.entity.User;
+import com.fitlife.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionServiceImplTest {
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private SubscriptionHistoryRepository subscriptionHistoryRepository;
+
+    @Mock
+    private GymPackageRepository gymPackageRepository;
+
+    @Mock
+    private PackageDurationRepository packageDurationRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private InvoiceService invoiceService;
+
+    @Mock
+    private SubscriptionMapper subscriptionMapper;
+
+    @InjectMocks
+    private SubscriptionServiceImpl subscriptionService;
+
+    @AfterEach
+    void clearSecurityContext() {
+        org.springframework.security.core.context.SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void createSubscription_shouldThrowException_whenActiveSubscriptionExists() {
+        // Mock authentication
+        org.springframework.security.core.context.SecurityContextHolder.getContext().setAuthentication(
+                new org.springframework.security.authentication.UsernamePasswordAuthenticationToken("member@example.com", null)
+        );
+
+        User user = new User();
+        user.setId(10L);
+        Member member = new Member();
+        member.setId(100L);
+
+        SubscriptionCreateRequest request = new SubscriptionCreateRequest();
+        request.setPackageDurationId(1L);
+        PackageDuration duration = PackageDuration.builder().id(1L).status("ACTIVE")
+                .gymPackage(GymPackage.builder().id(1L).status("ACTIVE").build()).build();
+
+        when(userRepository.findByUsername("member@example.com")).thenReturn(Optional.of(user));
+        when(memberRepository.findByUserId(10L)).thenReturn(Optional.of(member));
+        when(packageDurationRepository.findById(1L)).thenReturn(Optional.of(duration));
+        when(subscriptionRepository.existsByMemberIdAndStatus(100L, SubscriptionStatus.ACTIVE)).thenReturn(true);
+
+        assertThrows(AppException.class, () -> subscriptionService.createSubscription(request));
+    }
+
+    @Test
+    void activateSubscriptionAfterPayment_shouldTransitionStatus() {
+        Subscription subscription = Subscription.builder()
+                .id(1L)
+                .status(SubscriptionStatus.PENDING_PAYMENT)
+                .packageDuration(PackageDuration.builder().months(3).build())
+                .build();
+
+        when(subscriptionRepository.findById(1L)).thenReturn(Optional.of(subscription));
+        when(subscriptionRepository.save(any(Subscription.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        subscriptionService.activateSubscriptionAfterPayment(1L);
+
+        assertEquals(SubscriptionStatus.ACTIVE, subscription.getStatus());
+        assertNotNull(subscription.getStartDate());
+        assertNotNull(subscription.getEndDate());
+        verify(subscriptionHistoryRepository).save(any(SubscriptionHistory.class));
+    }
+
+    @Test
+    void activateSubscriptionAfterPayment_shouldCancelOldSubscription_whenUpgrade() {
+        Subscription newSub = Subscription.builder()
+                .id(2L)
+                .status(SubscriptionStatus.PENDING_PAYMENT)
+                .note("UPGRADE_FROM_1")
+                .packageDuration(PackageDuration.builder().months(6).build())
+                .build();
+
+        Subscription oldSub = Subscription.builder()
+                .id(1L)
+                .status(SubscriptionStatus.ACTIVE)
+                .startDate(LocalDate.now().minusDays(10))
+                .endDate(LocalDate.now().plusDays(20))
+                .build();
+
+        when(subscriptionRepository.findById(2L)).thenReturn(Optional.of(newSub));
+        when(subscriptionRepository.findById(1L)).thenReturn(Optional.of(oldSub));
+        when(subscriptionRepository.save(any(Subscription.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        subscriptionService.activateSubscriptionAfterPayment(2L);
+
+        assertEquals(SubscriptionStatus.ACTIVE, newSub.getStatus());
+        assertEquals(SubscriptionStatus.CANCELLED, oldSub.getStatus());
+        assertTrue(oldSub.getNote().contains("Upgraded to subscription 2"));
+        verify(subscriptionHistoryRepository, times(2)).save(any(SubscriptionHistory.class));
+    }
+
+    @Test
+    void activateSubscriptionAfterPayment_shouldNotOverwriteDates_whenRenewal() {
+        LocalDate futureStartDate = LocalDate.now().plusDays(15);
+        LocalDate futureEndDate = futureStartDate.plusMonths(1);
+
+        Subscription subscription = Subscription.builder()
+                .id(3L)
+                .status(SubscriptionStatus.PENDING_PAYMENT)
+                .note("Renew of subscription 1")
+                .startDate(futureStartDate)
+                .endDate(futureEndDate)
+                .packageDuration(PackageDuration.builder().months(1).build())
+                .build();
+
+        when(subscriptionRepository.findById(3L)).thenReturn(Optional.of(subscription));
+        when(subscriptionRepository.save(any(Subscription.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        subscriptionService.activateSubscriptionAfterPayment(3L);
+
+        assertEquals(SubscriptionStatus.ACTIVE, subscription.getStatus());
+        assertEquals(futureStartDate, subscription.getStartDate());
+        assertEquals(futureEndDate, subscription.getEndDate());
+        verify(subscriptionHistoryRepository).save(any(SubscriptionHistory.class));
+    }
+}


### PR DESCRIPTION
fix(membership): align gym package, package duration, and subscription lifecycles
- fix(duration): resolve db constraint violation in global create duration by associating gym package and price payload
- fix(duration): map GET /package-durations/active and support both PUT and PATCH on admin update duration
- fix(subscription): map GET /subscriptions/me and /subscriptions/me/active aliases
- fix(subscription): permit STAFF role to perform GET requests on admin subscriptions endpoints
- feat(subscription): implement automatic cancellation of old subscription upon upgrade activation
- feat(subscription): preserve pre-calculated future start/end dates for paid renewals
- test: add 11 unit tests covering PackageDurationServiceImpl and SubscriptionServiceImpl